### PR TITLE
Add video support to visualizer grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
       </div>
       <div id="vizTagBar" class="tagbar"></div>
       <div id="vizContainer"></div>
-      <div id="vizEmpty" class="empty" style="display:none">No images found</div>
+      <div id="vizEmpty" class="empty" style="display:none">No media found</div>
     </section>
 
     <!-- Waiting Rooms -->
@@ -2087,9 +2087,9 @@
       vizPortalFilter.appendChild(o); 
     });
 
-    vizTagBar.innerHTML=''; 
-    const allTags = Array.from(new Set((state.images||[]).flatMap(i=>i.tags||[]))).sort((a,b)=> a.localeCompare(b));
-    allTags.forEach(t=>{ 
+    vizTagBar.innerHTML='';
+    const allTags = Array.from(new Set([...(state.images||[]), ...(state.videos||[])].flatMap(i=>i.tags||[]))).sort((a,b)=> a.localeCompare(b));
+    allTags.forEach(t=>{
       const chip=document.createElement('span'); 
       chip.className='tag'; 
       chip.textContent=t; 
@@ -2108,14 +2108,15 @@
     const pfIdx = pf===''? null : parseInt(pf,10);
 
     const byPortal=new Map();
-    function addToGroup(rec){ 
-      const key = rec.portalIndex!=null? rec.portalIndex : -1; 
-      if(!byPortal.has(key)) byPortal.set(key, []); 
-      byPortal.get(key).push(rec); 
+    function addToGroup(rec){
+      const key = rec.portalIndex!=null? rec.portalIndex : -1;
+      if(!byPortal.has(key)) byPortal.set(key, []);
+      byPortal.get(key).push(rec);
     }
 
-    (state.images||[]).forEach(img=> addToGroup(img));
-    derived.forEach(img=> addToGroup(img));
+    (state.images||[]).forEach(img=> addToGroup({...img, type:'image'}));
+    (state.videos||[]).forEach(vid=> addToGroup({...vid, type:'video'}));
+    derived.forEach(img=> addToGroup({...img, type:'image'}));
 
     for(const [k,arr] of byPortal.entries()){
       byPortal.set(k, arr.filter(rec=>{
@@ -2148,14 +2149,29 @@
       const grid=document.createElement('div'); 
       grid.className='viz-grid';
       items.forEach(it=>{
-        const th=document.createElement('div'); 
-        th.className='viz-thumb'; 
-        th.style.backgroundImage=`url(${it.src})`;
-        const cap=document.createElement('div'); 
-        cap.className='cap'; 
-        cap.textContent=it.name || (it.derived? 'Embedded' : 'Image'); 
+        const th=document.createElement('div');
+        th.className='viz-thumb';
+        if(it.type==='video'){
+          const vid=document.createElement('video');
+          vid.src=it.src;
+          vid.muted=true;
+          vid.controls=true;
+          vid.style.width='100%';
+          vid.style.height='100%';
+          vid.style.objectFit='cover';
+          vid.style.position='absolute';
+          vid.style.inset='0';
+          if(it.poster) vid.poster=it.poster;
+          th.appendChild(vid);
+          th.style.cursor='default';
+        }else{
+          th.style.backgroundImage=`url(${it.src})`;
+          th.onclick=()=> openLightbox(it.src, `${title}${it.tags?.length? ' • '+it.tags.join(', '):''}`, it.derived ? null : it.id);
+        }
+        const cap=document.createElement('div');
+        cap.className='cap';
+        cap.textContent=it.name || (it.derived? 'Embedded' : (it.type==='video'? 'Video' : 'Image'));
         th.appendChild(cap);
-        th.onclick=()=> openLightbox(it.src, `${title}${it.tags?.length? ' • '+it.tags.join(', '):''}`, it.derived ? null : it.id);
         grid.appendChild(th);
       });
       grp.appendChild(grid); 


### PR DESCRIPTION
## Summary
- Combine images and videos when grouping visualizer items by portal
- Render video thumbnails with playable <video> elements and tag each record with type
- Tweak empty-state message to reflect both images and videos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d86c9cfbc832a87836b1a28057ff8