### PR TITLE
Handle embedded videos in visualizers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2054,19 +2054,35 @@
         if(!html) return; 
         const div=document.createElement('div'); 
         div.innerHTML=html; 
-        div.querySelectorAll('img').forEach((img,idx)=>{ 
-          const src=img.getAttribute('src'); 
-          if(src){ 
-            derived.push({ 
-              id:`drv_${pi}_${idx}_${Math.random().toString(36).slice(2)}`, 
-              src, 
-              name:`Embedded ${idx+1}`, 
-              portalIndex:pi, 
-              tags:['embedded'], 
-              created:0, 
-              derived:true 
-            }); 
-          } 
+        div.querySelectorAll('img').forEach((img,idx)=>{
+          const src=img.getAttribute('src');
+          if(src){
+            derived.push({
+              id:`drv_${pi}_${idx}_${Math.random().toString(36).slice(2)}`,
+              src,
+              name:`Embedded ${idx+1}`,
+              portalIndex:pi,
+              tags:['embedded'],
+              created:0,
+              derived:true
+            });
+          }
+        });
+        div.querySelectorAll('video, iframe').forEach((med,idx)=>{
+          const src=med.getAttribute('src');
+          if(src){
+            derived.push({
+              id:`drv_${pi}_${idx}_${Math.random().toString(36).slice(2)}`,
+              src,
+              name:`Embedded Video ${idx+1}`,
+              portalIndex:pi,
+              tags:['embedded'],
+              created:0,
+              derived:true,
+              type:'video',
+              tag: med.tagName.toLowerCase()
+            });
+          }
         });
       });
     });
@@ -2148,17 +2164,37 @@
       const grid=document.createElement('div'); 
       grid.className='viz-grid';
       items.forEach(it=>{
-        const th=document.createElement('div'); 
-        th.className='viz-thumb'; 
-        th.style.backgroundImage=`url(${it.src})`;
-        const cap=document.createElement('div'); 
-        cap.className='cap'; 
-        cap.textContent=it.name || (it.derived? 'Embedded' : 'Image'); 
+        const th=document.createElement('div');
+        th.className='viz-thumb';
+        if(it.type==='video'){
+          let media;
+          if(it.tag==='iframe'){
+            media=document.createElement('iframe');
+            media.src=it.src;
+            media.allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+            media.style.border='0';
+          }else{
+            media=document.createElement('video');
+            media.src=it.src;
+            media.controls=true;
+          }
+          media.style.position='absolute';
+          media.style.inset='0';
+          media.style.width='100%';
+          media.style.height='100%';
+          media.style.objectFit='cover';
+          th.appendChild(media);
+        }else{
+          th.style.backgroundImage=`url(${it.src})`;
+        }
+        const cap=document.createElement('div');
+        cap.className='cap';
+        cap.textContent=it.name || (it.derived? (it.type==='video'? 'Embedded Video' : 'Embedded') : 'Image');
         th.appendChild(cap);
-        th.onclick=()=> openLightbox(it.src, `${title}${it.tags?.length? ' • '+it.tags.join(', '):''}`, it.derived ? null : it.id);
+        th.onclick=()=> it.type==='video'? window.open(it.src,'_blank') : openLightbox(it.src, `${title}${it.tags?.length? ' • '+it.tags.join(', '):''}`, it.derived ? null : it.id);
         grid.appendChild(th);
       });
-      grp.appendChild(grid); 
+      grp.appendChild(grid);
       vizContainer.appendChild(grp);
     });
 


### PR DESCRIPTION
## Summary
- Scan portal sections for embedded `<video>` and `<iframe>` elements and derive video records
- Render video and iframe visualizers alongside images and open videos in a new tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d86d0dac4832aa1284de6b20b0464