### PR TITLE
Add launch scene and invoke portal renderer on startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,8 @@
 </style>
 </head>
 <body>
-<div class="app">
+<div id="launchScene"><canvas id="portalCanvas"></canvas><button id="enterApp">Enter Tracking App</button></div>
+<div class="app" style="display:none">
   <aside class="side">
     <div class="brand">
       <div class="logo">✨</div>
@@ -3614,6 +3615,7 @@
   
   tryParseImplicitToken();
   renderAll();
+  renderPortalScene();
   attachSettingsHandlers();
   setupAutoSync();
 


### PR DESCRIPTION
## Summary
- Insert launch scene with portal canvas and entry button
- Hide app container until launch
- Trigger `renderPortalScene()` after portal data loads

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d95b09ed0832aa2a1bd80d6bc082e