### PR TITLE
Add portal canvas panning and zoom interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1096,6 +1096,71 @@
   let portalSceneObjs=[];
   let offsetX=0, offsetY=0, scale=1;
 
+  portalCanvas.style.touchAction='none';
+  const activePointers=new Map();
+  let isDragging=false;
+  let lastX=0, lastY=0;
+  let startPinchDist=0;
+  let startScale=1;
+
+  portalCanvas.addEventListener('pointerdown',e=>{
+    activePointers.set(e.pointerId,e);
+    if(activePointers.size===1){
+      isDragging=true;
+      lastX=e.clientX;
+      lastY=e.clientY;
+    }else if(activePointers.size===2){
+      const [p1,p2]=Array.from(activePointers.values());
+      startPinchDist=Math.hypot(p1.clientX-p2.clientX,p1.clientY-p2.clientY);
+      startScale=scale;
+      isDragging=false;
+    }
+    portalCanvas.setPointerCapture(e.pointerId);
+  });
+
+  portalCanvas.addEventListener('pointermove',e=>{
+    if(!activePointers.has(e.pointerId)) return;
+    activePointers.set(e.pointerId,e);
+    if(isDragging && activePointers.size===1){
+      const dx=e.clientX-lastX;
+      const dy=e.clientY-lastY;
+      offsetX+=dx;
+      offsetY+=dy;
+      lastX=e.clientX;
+      lastY=e.clientY;
+    }else if(activePointers.size===2){
+      const [p1,p2]=Array.from(activePointers.values());
+      const dist=Math.hypot(p1.clientX-p2.clientX,p1.clientY-p2.clientY);
+      if(startPinchDist){
+        scale=startScale*dist/startPinchDist;
+        scale=Math.min(5,Math.max(0.2,scale));
+      }
+    }
+  });
+
+  function endPointer(e){
+    activePointers.delete(e.pointerId);
+    if(activePointers.size===0){
+      isDragging=false;
+      startPinchDist=0;
+    }else if(activePointers.size===1){
+      const rem=Array.from(activePointers.values())[0];
+      lastX=rem.clientX;
+      lastY=rem.clientY;
+      isDragging=true;
+    }
+  }
+
+  portalCanvas.addEventListener('pointerup',endPointer);
+  portalCanvas.addEventListener('pointercancel',endPointer);
+
+  portalCanvas.addEventListener('wheel',e=>{
+    e.preventDefault();
+    const factor=e.deltaY<0?1.1:0.9;
+    scale*=factor;
+    scale=Math.min(5,Math.max(0.2,scale));
+  },{passive:false});
+
   function renderPortalScene(){
     portalCanvas.width=portalCanvas.clientWidth;
     portalCanvas.height=portalCanvas.clientHeight;


### PR DESCRIPTION
## Summary
- Track pointer down/move/up events on `portalCanvas` to drag the scene and handle pinch gestures for mobile.
- Support mouse wheel zoom with clamped scale limits.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9b041cd4832aa2e7f54ae7ae618c