### PR TITLE
Refactor portal canvas sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1180,15 +1180,15 @@
     scale=Math.min(5,Math.max(0.2,scale));
   },{passive:false});
 
-  function resizePortalCanvas(){
-    portalCanvas.width=window.innerWidth;
-    portalCanvas.height=window.innerHeight;
+  function sizePortalCanvas(){
+    portalCanvas.width=portalCanvas.clientWidth;
+    portalCanvas.height=portalCanvas.clientHeight;
   }
 
-  window.addEventListener('resize',resizePortalCanvas);
+  window.addEventListener('resize',sizePortalCanvas);
 
   async function renderPortalScene(){
-    resizePortalCanvas();
+    sizePortalCanvas();
     portalSceneObjs=(state.portals||[]).map(p=>{
       const obj={
         x:Math.random()*portalCanvas.width,


### PR DESCRIPTION
## Summary
- Factor out `sizePortalCanvas` to sync canvas dimensions with its client size
- Resize the canvas on viewport changes and before building portal objects

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9fada29c832a9ebc2dfb24f26e09