### PR TITLE
Preload portal cover images before drawing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1189,6 +1189,7 @@
 
   async function renderPortalScene(){
     resizePortalCanvas();
+    const loadPromises=[];
     portalSceneObjs=(state.portals||[]).map(p=>{
       const obj={
         x:Math.random()*portalCanvas.width,
@@ -1200,14 +1201,14 @@
       if(p.cover){
         const img=new Image();
         obj.cover=img;
+        loadPromises.push(new Promise(res=>{
+          img.onload=()=>res();
+          img.onerror=()=>{ obj.cover=null; res(); };
+        }));
         img.src=p.cover;
       }
       return obj;
     });
-
-    const loadPromises=portalSceneObjs.filter(o=>o.cover).map(o=>new Promise(res=>{
-      if(o.cover.complete) res(); else { o.cover.onload=o.cover.onerror=res; }
-    }));
 
     await Promise.all(loadPromises);
 


### PR DESCRIPTION
## Summary
- Preload portal cover images with Promises before drawing portal scene
- Resolve image load errors by removing covers so portals fall back to colored circles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9fb17bc0832a97d61e14d017f710