### PR TITLE
Add parallax starfield backdrop to launch screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
 </style>
 </head>
 <body>
-<div id="launchScene"><canvas id="portalCanvas"></canvas><button id="enterApp">Enter Tracking App</button></div>
+<div id="launchScene"><canvas id="starfieldCanvas"></canvas><canvas id="portalCanvas"></canvas><button id="enterApp">Enter Tracking App</button></div>
 <div class="app" style="display:none">
   <aside class="side">
     <div class="brand">
@@ -1110,8 +1110,12 @@
   const portalGrid=qs('#portalGrid');
   const portalCanvas=qs('#portalCanvas');
   const portalCtx=portalCanvas.getContext('2d');
+  const starCanvas=qs('#starfieldCanvas');
+  const starCtx=starCanvas.getContext('2d');
+  let starLayers=[];
   let portalSceneObjs=[];
   let offsetX=0, offsetY=0, scale=1;
+  let tiltX=0, tiltY=0;
 
   portalCanvas.style.touchAction='none';
   const activePointers=new Map();
@@ -1197,6 +1201,51 @@
     portalCanvas.width=portalCanvas.clientWidth;
     portalCanvas.height=portalCanvas.clientHeight;
   }
+
+  function sizeStarCanvas(){
+    starCanvas.width=starCanvas.clientWidth;
+    starCanvas.height=starCanvas.clientHeight;
+  }
+
+  function initStarfield(){
+    sizeStarCanvas();
+    starLayers=[];
+    const layers=3;
+    for(let l=0;l<layers;l++){
+      const count=80*(l+1);
+      const layer=[];
+      for(let i=0;i<count;i++){
+        layer.push({
+          x:Math.random()*starCanvas.width,
+          y:Math.random()*starCanvas.height,
+          size:Math.random()*2+0.5
+        });
+      }
+      starLayers.push(layer);
+    }
+  }
+
+  function drawStarfield(){
+    starCtx.clearRect(0,0,starCanvas.width,starCanvas.height);
+    starLayers.forEach((layer,idx)=>{
+      const depth=(idx+1)/starLayers.length;
+      const parallax=depth*0.3;
+      starCtx.save();
+      starCtx.translate((offsetX+tiltX*20)*parallax,(offsetY+tiltY*20)*parallax);
+      layer.forEach(star=>{
+        starCtx.fillStyle='#fff';
+        starCtx.fillRect(star.x,star.y,star.size,star.size);
+      });
+      starCtx.restore();
+    });
+    requestAnimationFrame(drawStarfield);
+  }
+
+  window.addEventListener('resize',initStarfield);
+  window.addEventListener('deviceorientation',e=>{
+    tiltX=(e.gamma||0)/45;
+    tiltY=(e.beta||0)/45;
+  });
 
   window.addEventListener('resize',sizePortalCanvas);
 
@@ -3868,6 +3917,8 @@ const loadPromises = [];
   });
 
   tryParseImplicitToken();
+  initStarfield();
+  requestAnimationFrame(drawStarfield);
   renderAll();
   renderPortalScene();
   attachSettingsHandlers();


### PR DESCRIPTION
## Summary
- Add dedicated starfield canvas behind portal canvas in launch scene
- Render multiple star layers with depth-based parallax responding to drag or tilt
- Resize starfield with viewport to keep backdrop coverage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da62e8804832aad117e1883cb854a