### PR TITLE
Mask portal orbs and add glow effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,10 @@
   .viz-thumb{position:relative; width:100%; padding-top:100%; border:1px solid var(--border); border-radius:14px; background:#111317 center/cover no-repeat; cursor:pointer; overflow:hidden}
   .viz-thumb .cap{position:absolute; inset:auto 0 0 0; padding:6px 8px; background:linear-gradient(180deg, transparent, rgba(0,0,0,.55)); font-size:12px}
   #launchScene{position:fixed; inset:0; background:#000; transition:opacity .5s}
-  #launchScene canvas{position:absolute; top:0; left:0; width:100%; height:100%}
+  #launchScene canvas{position:absolute; top:0; left:0; width:100%; height:100%;
+    /* subtle glow and shadow around orbs */
+    filter: drop-shadow(0 0 6px rgba(255,255,255,.15)) drop-shadow(0 2px 4px rgba(0,0,0,.6));
+  }
   #enterApp{position:absolute; left:50%; bottom:20px; transform:translateX(-50%); z-index:1000}
 </style>
 </head>
@@ -1235,14 +1238,51 @@ const loadPromises = [];
       portalCtx.translate(offsetX,offsetY);
       portalCtx.scale(scale,scale);
       portalSceneObjs.forEach(o=>{
+        // drop shadow behind orb
+        portalCtx.save();
+        portalCtx.shadowColor='rgba(0,0,0,0.5)';
+        portalCtx.shadowBlur=10;
+        portalCtx.shadowOffsetX=0;
+        portalCtx.shadowOffsetY=2;
+        portalCtx.beginPath();
+        portalCtx.arc(o.x,o.y,o.r,0,Math.PI*2);
+        portalCtx.fillStyle='rgba(0,0,0,0)';
+        portalCtx.fill();
+        portalCtx.restore();
+
+        // draw orb with circular mask
+        portalCtx.save();
+        portalCtx.beginPath();
+        portalCtx.arc(o.x,o.y,o.r,0,Math.PI*2);
+        portalCtx.clip();
         if(o.cover){
           portalCtx.drawImage(o.cover,o.x-o.r,o.y-o.r,o.r*2,o.r*2);
         }else{
           portalCtx.fillStyle=o.color;
-          portalCtx.beginPath();
-          portalCtx.arc(o.x,o.y,o.r,0,Math.PI*2);
-          portalCtx.fill();
+          portalCtx.fillRect(o.x-o.r,o.y-o.r,o.r*2,o.r*2);
         }
+        // soften edges into background
+        const fade=portalCtx.createRadialGradient(o.x,o.y,o.r*0.8,o.x,o.y,o.r);
+        fade.addColorStop(0,'rgba(0,0,0,0)');
+        fade.addColorStop(1,'rgba(0,0,0,1)');
+        portalCtx.globalCompositeOperation='destination-out';
+        portalCtx.fillStyle=fade;
+        portalCtx.beginPath();
+        portalCtx.arc(o.x,o.y,o.r,0,Math.PI*2);
+        portalCtx.fill();
+        portalCtx.globalCompositeOperation='source-over';
+        portalCtx.restore();
+
+        // outer glow
+        portalCtx.save();
+        portalCtx.shadowColor='rgba(255,255,255,0.6)';
+        portalCtx.shadowBlur=15;
+        portalCtx.beginPath();
+        portalCtx.arc(o.x,o.y,o.r,0,Math.PI*2);
+        portalCtx.strokeStyle='rgba(255,255,255,0.2)';
+        portalCtx.lineWidth=2;
+        portalCtx.stroke();
+        portalCtx.restore();
       });
       portalCtx.restore();
       requestAnimationFrame(draw);


### PR DESCRIPTION
## Summary
- Mask each portal image as a circular orb with soft edges
- Add canvas-based drop shadow and outer glow rendering
- Apply CSS drop-shadow filter for subtle glow around portal scene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da62f7cc8832abe5af7e53992f184