### PR TITLE
Add inertial orb dragging with right-click/two-finger pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -1114,25 +1114,32 @@
   let offsetX=0, offsetY=0, scale=1;
 
   portalCanvas.style.touchAction='none';
+  portalCanvas.addEventListener('contextmenu',e=>e.preventDefault());
   const activePointers=new Map();
-  let isDragging=false;
+  let isPanning=false;
   let lastX=0, lastY=0;
   let startPinchDist=0;
   let startScale=1;
+  let startMidX=0, startMidY=0;
+  let startOffsetX=0, startOffsetY=0;
   let dragMoved=false;
 
   portalCanvas.addEventListener('pointerdown',e=>{
     activePointers.set(e.pointerId,e);
     if(activePointers.size===1){
-      isDragging=true;
       dragMoved=false;
       lastX=e.clientX;
       lastY=e.clientY;
+      isPanning = (e.button===2);
     }else if(activePointers.size===2){
       const [p1,p2]=Array.from(activePointers.values());
       startPinchDist=Math.hypot(p1.clientX-p2.clientX,p1.clientY-p2.clientY);
       startScale=scale;
-      isDragging=false;
+      startMidX=(p1.clientX+p2.clientX)/2;
+      startMidY=(p1.clientY+p2.clientY)/2;
+      startOffsetX=offsetX;
+      startOffsetY=offsetY;
+      isPanning=true;
       dragMoved=true;
     }
     portalCanvas.setPointerCapture(e.pointerId);
@@ -1141,12 +1148,24 @@
   portalCanvas.addEventListener('pointermove',e=>{
     if(!activePointers.has(e.pointerId)) return;
     activePointers.set(e.pointerId,e);
-    if(isDragging && activePointers.size===1){
+    if(activePointers.size===1){
       const dx=e.clientX-lastX;
       const dy=e.clientY-lastY;
       if(Math.abs(dx)>3 || Math.abs(dy)>3) dragMoved=true;
-      offsetX+=dx;
-      offsetY+=dy;
+      if(isPanning){
+        offsetX+=dx;
+        offsetY+=dy;
+      }else{
+        const rect=portalCanvas.getBoundingClientRect();
+        const x=(e.clientX-rect.left-offsetX)/scale;
+        const y=(e.clientY-rect.top-offsetY)/scale;
+        portalSceneObjs.forEach(o=>{
+          if(Math.hypot(o.x-x,o.y-y)<o.r*2){
+            o.vx+=(dx/scale)*0.2;
+            o.vy+=(dy/scale)*0.2;
+          }
+        });
+      }
       lastX=e.clientX;
       lastY=e.clientY;
     }else if(activePointers.size===2){
@@ -1156,11 +1175,15 @@
         scale=startScale*dist/startPinchDist;
         scale=Math.min(5,Math.max(0.2,scale));
       }
+      const midX=(p1.clientX+p2.clientX)/2;
+      const midY=(p1.clientY+p2.clientY)/2;
+      offsetX=startOffsetX+(midX-startMidX);
+      offsetY=startOffsetY+(midY-startMidY);
     }
   });
 
   function endPointer(e){
-    if(e.type==='pointerup' && !dragMoved){
+    if(e.type==='pointerup' && e.button===0 && !dragMoved){
       const rect=portalCanvas.getBoundingClientRect();
       const x=(e.clientX-rect.left-offsetX)/scale;
       const y=(e.clientY-rect.top-offsetY)/scale;
@@ -1173,13 +1196,13 @@
     }
     activePointers.delete(e.pointerId);
     if(activePointers.size===0){
-      isDragging=false;
+      isPanning=false;
       startPinchDist=0;
     }else if(activePointers.size===1){
       const rem=Array.from(activePointers.values())[0];
       lastX=rem.clientX;
       lastY=rem.clientY;
-      isDragging=true;
+      isPanning=false;
     }
   }
 
@@ -1213,7 +1236,9 @@ const loadPromises = [];
         y:Math.random()*portalCanvas.height,
         r:20+Math.random()*30,
         color:`hsl(${Math.random()*360},70%,60%)`,
-        cover:null
+        cover:null,
+        vx:0,
+        vy:0
       };
       if(p.cover){
         const img=new Image();
@@ -1235,6 +1260,14 @@ const loadPromises = [];
       portalCtx.translate(offsetX,offsetY);
       portalCtx.scale(scale,scale);
       portalSceneObjs.forEach(o=>{
+        o.x+=o.vx;
+        o.y+=o.vy;
+        o.vx*=0.95;
+        o.vy*=0.95;
+        if(o.x<o.r){o.x=o.r;o.vx*=-0.5;}
+        else if(o.x>portalCanvas.width-o.r){o.x=portalCanvas.width-o.r;o.vx*=-0.5;}
+        if(o.y<o.r){o.y=o.r;o.vy*=-0.5;}
+        else if(o.y>portalCanvas.height-o.r){o.y=portalCanvas.height-o.r;o.vy*=-0.5;}
         if(o.cover){
           portalCtx.drawImage(o.cover,o.x-o.r,o.y-o.r,o.r*2,o.r*2);
         }else{


### PR DESCRIPTION
## Summary
- Replace left-click dragging with velocity impulses on nearby orbs
- Track per-orb velocity and update motion with friction and boundary bounces
- Reserve scene panning for right-click or two-finger drag while keeping pinch-zoom

## Testing
- ❌ `npm test` *(package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da631885c832a9923b16cd3bb93b0