### PR TITLE
Fix portal scene mapping syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -1407,7 +1407,6 @@ if (src) {
   }
 }
 
-      }
       return obj;
     });
 
@@ -1486,10 +1485,6 @@ if (img) {
 
 portalCtx.restore(); // end circular clip
 
-        }else{
-          portalCtx.fillStyle=o.color;
-          portalCtx.fillRect(o.x-o.r,o.y-o.r,o.r*2,o.r*2);
-        }
         // soften edges into background
         const fade=portalCtx.createRadialGradient(o.x,o.y,o.r*0.8,o.x,o.y,o.r);
         fade.addColorStop(0,'rgba(0,0,0,0)');


### PR DESCRIPTION
## Summary
- remove stray closing brace so renderPortalScene's map callback returns correctly
- drop orphaned else block after orb clipping to prevent script parse error

## Testing
- `node -e "const puppeteer=require('puppeteer');(async()=>{const browser=await puppeteer.launch({args:['--no-sandbox']});const page=await browser.newPage();page.on('console',msg=>console.log('PAGE LOG:',msg.text()));page.on('pageerror',err=>console.log('PAGE ERROR:',err.message));await page.goto('file:///workspace/drscript3/index.html');await page.waitForSelector('#enterApp');await page.click('#enterApp');await new Promise(r=>setTimeout(r,600));const state=await page.evaluate(()=>{const launch=document.getElementById('launchScene');const app=document.querySelector('.app');return {launchDisplay:getComputedStyle(launch).display,appDisplay:getComputedStyle(app).display,launchOpacity:getComputedStyle(launch).opacity,appOpacity:getComputedStyle(app).opacity};});console.log('state after click',state);await browser.close();})();"`

------
https://chatgpt.com/codex/tasks/task_e_689db3dbc350832a85ee04c5804802eb