### PR TITLE
Delay heavy initialization until after entering app

### DIFF
--- a/index.html
+++ b/index.html
@@ -4126,17 +4126,22 @@ portalCtx.restore(); // end circular clip
   tryParseImplicitToken();
   initStarfield();
   requestAnimationFrame(drawStarfield);
-  renderAll();
-  renderPortalScene();
-  attachSettingsHandlers();
-  setupAutoSync();
-
+  // Delay heavy initialization until the user enters the app
   qs('#enterApp').addEventListener('click', () => {
     const launch = qs('#launchScene');
     const app = qs('.app');
     launch.style.opacity = '0';
     app.style.display = 'grid';
-    requestAnimationFrame(() => app.style.opacity = '1');
+    requestAnimationFrame(() => {
+      app.style.opacity = '1';
+      // Use idle callback when available to keep the UI responsive
+      (window.requestIdleCallback || requestAnimationFrame)(() => {
+        renderAll();
+        renderPortalScene();
+        attachSettingsHandlers();
+        setupAutoSync();
+      });
+    });
     setTimeout(() => launch.style.display = 'none', 500);
   });
 


### PR DESCRIPTION
## Summary
- Defer heavy rendering and setup routines until the user clicks **Enter App**
- Use `requestIdleCallback`/`requestAnimationFrame` within the click handler to keep the UI responsive during initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dbbc61f44832aba89614aceabb445