### PR TITLE
Refactor portal dragging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1175,7 +1175,7 @@ let tiltX = 0, tiltY = 0;
   let startMidX=0, startMidY=0;
   let startOffsetX=0, startOffsetY=0;
   let dragMoved=false;
-  let draggedPortal=null;
+  let dragPortal=null;
   let dragPointerId=null;
 
   portalCanvas.addEventListener('pointerdown',e=>{
@@ -1184,7 +1184,7 @@ let tiltX = 0, tiltY = 0;
       dragMoved=false;
       lastX=e.clientX;
       lastY=e.clientY;
-// Right-click pans; left/middle drag/nudge objects in the portal preview
+// Right-click pans; left/middle drag objects in the portal preview
 isPanning = (e.button === 2);
 
 if (!isPanning) {
@@ -1193,26 +1193,14 @@ if (!isPanning) {
   const y = (e.clientY - rect.top - offsetY) / scale;
 
   // Pick a nearby portal to interact with
-  draggedPortal = portalSceneObjs.find(o => Math.hypot(o.x - x, o.y - y) < o.r * 2) || null;
-  dragPointerId = draggedPortal ? e.pointerId : null;
+  dragPortal = portalSceneObjs.find(o => Math.hypot(o.x - x, o.y - y) < o.r * 2) || null;
+  dragPointerId = dragPortal ? e.pointerId : null;
 
-  if (draggedPortal) {
-    // Subtle impulse so it feels responsive/alive
-    draggedPortal.vx     += (Math.random() - 0.5) * 2;
-    draggedPortal.vy     += (Math.random() - 0.5) * 2;
-    draggedPortal.angVel += (Math.random() - 0.5) * 0.05;
-    draggedPortal.angle  += (Math.random() - 0.5) * 0.5;
-    draggedPortal.orbitRadius *= 1 + (Math.random() - 0.5) * 0.1;
-    draggedPortal.cx     += (Math.random() - 0.5) * 10;
-    draggedPortal.cy     += (Math.random() - 0.5) * 10;
-
-    // Ensure we keep getting move/up events for smooth dragging
-    if (portalCanvas.setPointerCapture) {
-      try { portalCanvas.setPointerCapture(e.pointerId); } catch {}
-    }
+  if (dragPortal && portalCanvas.setPointerCapture) {
+    try { portalCanvas.setPointerCapture(e.pointerId); } catch {}
   }
 } else {
-  draggedPortal = null;
+  dragPortal = null;
   dragPointerId = null;
 }
 
@@ -1240,9 +1228,11 @@ if (!isPanning) {
       if(isPanning){
         offsetX+=dx;
         offsetY+=dy;
-      }else if(draggedPortal && e.pointerId===dragPointerId){
-        draggedPortal.vx += (dx/scale)*0.05;
-        draggedPortal.vy += (dy/scale)*0.05;
+      }else if(dragPortal && e.pointerId===dragPointerId){
+        dragPortal.cx += dx/scale;
+        dragPortal.cy += dy/scale;
+        dragPortal.x = dragPortal.cx + Math.cos(dragPortal.angle) * dragPortal.orbitRadius;
+        dragPortal.y = dragPortal.cy + Math.sin(dragPortal.angle) * dragPortal.orbitRadius;
       }
       lastX=e.clientX;
       lastY=e.clientY;
@@ -1264,22 +1254,15 @@ if (!isPanning) {
 if (
   e.type === 'pointerup' &&
   !dragMoved &&
+  dragPortal &&
+  e.pointerId===dragPointerId &&
   ((e.pointerType === 'mouse' && e.button === 0) || e.pointerType === 'touch' || e.pointerType === 'pen')
 ){
-
-      const rect=portalCanvas.getBoundingClientRect();
-      const x=(e.clientX-rect.left-offsetX)/scale;
-      const y=(e.clientY-rect.top-offsetY)/scale;
-      portalSceneObjs.some(o=>{
-        if(Math.hypot(o.x-x,o.y-y)<o.r){
-          showPortalSummary(o.portal);
-          return true;
-        }
-      });
+      showPortalSummary(dragPortal.portal);
     }
     activePointers.delete(e.pointerId);
     if(e.pointerId===dragPointerId){
-      draggedPortal=null;
+      dragPortal=null;
       dragPointerId=null;
     }
     if(activePointers.size===0){


### PR DESCRIPTION
## Summary
- Remove random motion when picking up a portal
- Track active drag portal and move it by updating its position directly
- Use stored drag portal to detect clicks vs drags

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/drscript3/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689dbd944d94832a9866317d7a6bce43