### PR TITLE
Add parallax motion and opacity to starfield

### DIFF
--- a/index.html
+++ b/index.html
@@ -1310,11 +1310,15 @@ if (
     for(let l=0;l<layers;l++){
       const count=80*(l+1);
       const layer=[];
+      const depth=(l+1)/layers;
       for(let i=0;i<count;i++){
         layer.push({
           x:Math.random()*starCanvas.width,
           y:Math.random()*starCanvas.height,
-          size:Math.random()*2+0.5
+          size:Math.random()*2+0.5,
+          vx:(Math.random()-0.5)*0.05,
+          vy:(Math.random()-0.5)*0.05,
+          alpha:1-depth*0.5
         });
       }
       starLayers.push(layer);
@@ -1329,6 +1333,11 @@ if (
       starCtx.save();
       starCtx.translate((offsetX+tiltX*20)*parallax,(offsetY+tiltY*20)*parallax);
       layer.forEach(star=>{
+        star.x+=star.vx*depth;
+        star.y+=star.vy*depth;
+        star.x=(star.x+starCanvas.width)%starCanvas.width;
+        star.y=(star.y+starCanvas.height)%starCanvas.height;
+        starCtx.globalAlpha=star.alpha;
         starCtx.fillStyle='#fff';
         starCtx.fillRect(star.x,star.y,star.size,star.size);
       });


### PR DESCRIPTION
## Summary
- Add velocity and alpha properties to stars when initializing the starfield
- Update starfield rendering to move stars with depth-based motion, wrap edges, and draw with per-star opacity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc308efa0832a8eb1bcf681895274