### PR TITLE
Render portals and starfield before entering app

### DIFF
--- a/index.html
+++ b/index.html
@@ -4128,6 +4128,7 @@ portalCtx.restore(); // end circular clip
   tryParseImplicitToken();
   initStarfield();
   requestAnimationFrame(drawStarfield);
+  renderPortalScene();
   // Delay heavy initialization until the user enters the app
   qs('#enterApp').addEventListener('click', () => {
     const launch = qs('#launchScene');
@@ -4139,7 +4140,6 @@ portalCtx.restore(); // end circular clip
       // Use idle callback when available to keep the UI responsive
       (window.requestIdleCallback || requestAnimationFrame)(() => {
         renderAll();
-        renderPortalScene();
         attachSettingsHandlers();
         setupAutoSync();
       });


### PR DESCRIPTION
## Summary
- Render portal canvas as soon as the page loads
- Initialize starfield animation prior to clicking "Enter Tracking App"
- Keep heavy setup until after entering the app

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc8a21274832aabe9b6ccd781bcba