### PR TITLE
Ensure starfield initializes on load and handles draw errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1316,8 +1316,8 @@ if (
           x:Math.random()*starCanvas.width,
           y:Math.random()*starCanvas.height,
           size:Math.random()*2+0.5,
-          vx:(Math.random()-0.5)*0.05,
-          vy:(Math.random()-0.5)*0.05,
+          vx:(Math.random()-0.5)*0.2,
+          vy:(Math.random()-0.5)*0.2,
           alpha:1-depth*0.5
         });
       }
@@ -1326,24 +1326,27 @@ if (
   }
 
   function drawStarfield(){
-    starCtx.clearRect(0,0,starCanvas.width,starCanvas.height);
-    starLayers.forEach((layer,idx)=>{
-      const depth=(idx+1)/starLayers.length;
-      const parallax=depth*0.3;
-      starCtx.save();
-      starCtx.translate((offsetX+tiltX*20)*parallax,(offsetY+tiltY*20)*parallax);
-      layer.forEach(star=>{
-        star.x+=star.vx*depth;
-        star.y+=star.vy*depth;
-        star.x=(star.x+starCanvas.width)%starCanvas.width;
-        star.y=(star.y+starCanvas.height)%starCanvas.height;
-        starCtx.globalAlpha=star.alpha;
-        starCtx.fillStyle='#fff';
-        starCtx.fillRect(star.x,star.y,star.size,star.size);
+    try {
+      starCtx.clearRect(0,0,starCanvas.width,starCanvas.height);
+      starLayers.forEach((layer,idx)=>{
+        const depth=(idx+1)/starLayers.length;
+        const parallax=depth*0.3;
+        starCtx.save();
+        starCtx.translate((offsetX+tiltX*20)*parallax,(offsetY+tiltY*20)*parallax);
+        layer.forEach(star=>{
+          star.x+=star.vx*depth;
+          star.y+=star.vy*depth;
+          star.x=(star.x+starCanvas.width)%starCanvas.width;
+          star.y=(star.y+starCanvas.height)%starCanvas.height;
+          starCtx.globalAlpha=star.alpha;
+          starCtx.fillStyle='#fff';
+          starCtx.fillRect(star.x,star.y,star.size,star.size);
+        });
+        starCtx.restore();
       });
-      starCtx.restore();
-    });
-    requestAnimationFrame(drawStarfield);
+    } finally {
+      requestAnimationFrame(drawStarfield);
+    }
   }
 
   window.addEventListener('resize',initStarfield);
@@ -4134,8 +4137,10 @@ portalCtx.restore(); // end circular clip
   });
 
   tryParseImplicitToken();
-  initStarfield();
-  requestAnimationFrame(drawStarfield);
+  window.addEventListener('load', () => {
+    initStarfield();
+    requestAnimationFrame(drawStarfield);
+  });
   renderPortalScene();
   // Delay heavy initialization until the user enters the app
   qs('#enterApp').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Start starfield animation once the window loads
- Continue starfield animation even if an error occurs while drawing
- Increase default star velocity for a livelier effect

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689e8aeebdd0832aaa68d5d3a2ecec9b