### PR TITLE
Render portals at launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -4145,6 +4145,8 @@ portalCtx.restore(); // end circular clip
   window.addEventListener('load', () => {
     initStarfield();
     requestAnimationFrame(drawStarfield);
+    sizePortalCanvas();
+    renderPortalScene();
   });
   // Delay heavy initialization until the user enters the app
   qs('#enterApp').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Render saved portal scene on window load
- Call `sizePortalCanvas` and `renderPortalScene` during initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9055e750832abb8d83f31db2d1b6