### PR TITLE
feat: migrate legacy localStorage data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1049,7 +1049,9 @@
 <script>
   // ===== State =====
   const storeKey='drsb-data-v2';
-  let state = load() || { 
+  let state = load();
+  if(state && !localStorage.getItem(storeKey)) save();
+  if(!state) state={
     portals:[], 
     waitingRooms:[], 
     journal:[], 
@@ -1095,7 +1097,17 @@
       }, 100);
     }
   }
-  function load(){ try{ return JSON.parse(localStorage.getItem(storeKey)||''); }catch{return null} }
+  function load(){
+    const v2 = localStorage.getItem(storeKey);
+    if (v2) {
+      try { return JSON.parse(v2); } catch { return null; }
+    }
+    const legacy = localStorage.getItem('drsb-data');
+    if (legacy) {
+      try { return JSON.parse(legacy); } catch { return null; }
+    }
+    return null;
+  }
   function uid(){ return Math.random().toString(36).slice(2)+Date.now().toString(36); }
   function toLocalInput(iso){ try{ const d=new Date(iso); const pad=n=>String(n).padStart(2,'0'); return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`; }catch{ return ''; } }
 


### PR DESCRIPTION
## Summary
- load state from legacy `drsb-data` if `drsb-data-v2` is missing
- persist migrated legacy data under `drsb-data-v2`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9298eae8832a80e145a92998efa4