### PR TITLE
Handle local save errors gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,11 +1095,18 @@
       localStorage.setItem(storeKey, JSON.stringify(state));
     }catch(err){
       if(err?.name==='QuotaExceededError'){
-        quota=true;
         console.warn('Storage quota exceeded, state not fully saved');
       }else{
         console.error('Save failed', err);
       }
+      setSyncStatus('Local save failed: ' + err.message);
+      const m = qs('#storageModal');
+      if(m){
+        m.classList.add('open');
+      }else if(typeof alert==='function'){
+        alert('Local save failed. Try freeing up storage or checking browser settings.');
+      }
+      return;
     }
     if(state.sync){
       try{


### PR DESCRIPTION
## Summary
- Report local save failures via setSyncStatus and optional modal alert.
- Abort save routine early when local storage write fails to allow app flow to continue.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9f704978832aa53da4e86378c4f7