### PR TITLE
feat: use font variables for aurora typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   }
   *{box-sizing:border-box}
   html,body{height:100%}
-  body{margin:0; color:var(--ink); background:radial-gradient(1200px 800px at 10% -10%, rgba(124,108,255,.08), transparent 55%), radial-gradient(900px 700px at 110% 20%, rgba(139,92,246,.06), transparent 60%), var(--bg-primary); font:400 16px/1.6 Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial}
+  body{margin:0; color:var(--ink); background:radial-gradient(1200px 800px at 10% -10%, rgba(124,108,255,.08), transparent 55%), radial-gradient(900px 700px at 110% 20%, rgba(139,92,246,.06), transparent 60%), var(--bg-primary); font-size:16px; line-height:1.6; font-weight:400; font-family:var(--ff-ui);}
 
   .app{display:grid; grid-template-columns:280px 1fr; min-height:100vh; transition:opacity .5s; opacity:0}
 

--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -1,19 +1,22 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@500;700&family=Space+Mono:wght@400;700&display=swap');
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--ff-ui);
 }
 
 .title, h1, h2, h3 {
-  font-family: 'Playfair Display', serif;
+  font-family: var(--ff-h);
 }
 
 .log, .codey {
-  font-family: 'Space Mono', monospace;
+  font-family: var(--ff-mono);
 }
 
 /* Aurora theme tokens */
 .theme-aurora {
+  --ff-ui: 'Inter', system-ui, sans-serif;
+  --ff-h: 'Playfair Display', serif;
+  --ff-mono: 'Space Mono', monospace;
   --bg-0: #0a0e16;
   --bg-1: #0f1420;
   --ink: #e8e9ef;


### PR DESCRIPTION
## Summary
- define `--ff-ui`, `--ff-h`, and `--ff-mono` custom properties in `.theme-aurora`
- apply font-family variables for body, headings, and monospaced elements

## Testing
- `node verify-fonts.js 2>/tmp/font-errors.log | tail -n 3`

------
https://chatgpt.com/codex/tasks/task_e_689ebcbe3470832ab72b9d639b94ca52