### PR TITLE
Add aurora overlay and animation

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -41,3 +41,32 @@ body {
 .theme-aurora body {
   background: radial-gradient(circle at 50% 30%, var(--bg-1), var(--bg-0) 70%);
 }
+
+.theme-aurora body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 20% 20%, var(--aurora-1), transparent 60%),
+    radial-gradient(circle at 80% 20%, var(--aurora-2), transparent 60%),
+    radial-gradient(circle at 50% 80%, var(--aurora-3), var(--aurora-4) 60%, transparent 70%);
+  mix-blend-mode: screen;
+  filter: blur(40px);
+  opacity: .35;
+  animation: aurora 28s linear infinite alternate;
+  z-index: -1;
+}
+
+.theme-aurora #starfieldCanvas {
+  z-index: -2;
+}
+
+@keyframes aurora {
+  0% {
+    transform: translate3d(-10%, -10%, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(10%, 10%, 0) scale(1.1);
+  }
+}


### PR DESCRIPTION
## Summary
- Add body::before aurora overlay using radial gradients and blur
- Animate aurora layer with subtle translation and scaling
- Layer aurora above starfield canvas via z-index adjustments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ebfbac7ec832a98059ad7b9b9e1c2