### PR TITLE
feat: apply glass styling to surfaces

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -64,6 +64,14 @@ body {
   display: block;
 }
 
+.card, .panel, .sidebar {
+  background:var(--glass);
+  border:1px solid var(--border);
+  backdrop-filter:blur(12px) saturate(120%);
+  border-radius:16px;
+  box-shadow:var(--shadow);
+}
+
 @keyframes aurora {
   0% {
     transform: translate3d(-10%, -10%, 0) scale(1);


### PR DESCRIPTION
## Summary
- style card, panel, and sidebar with glass surface variables

## Testing
- `python - <<'PY'
from colorsys import rgb_to_hls

def srgb_to_luminance(r,g,b):
    # r,g,b are 0-255
    def channel(c):
        c = c/255
        return c/12.92 if c<=0.03928 else ((c+0.055)/1.055)**2.4
    R,G,B = channel(r), channel(g), channel(b)
    return 0.2126*R + 0.7152*G + 0.0722*B

def contrast_ratio(c1,c2):
    L1 = srgb_to_luminance(*c1)
    L2 = srgb_to_luminance(*c2)
    L1, L2 = max(L1,L2), min(L1,L2)
    return (L1+0.05)/(L2+0.05)

ink = (0xe8,0xe9,0xef)
# glass color rgba(18,22,30,0.55) over bg1 (15,20,32)
fg=(18,22,30)
alpha=0.55
bg=(15,20,32)
comp = tuple(int(alpha*f + (1-alpha)*b) for f,b in zip(fg,bg))
print('Composite color:', comp)
print('Contrast ratio:', contrast_ratio(ink, comp))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689ec1c08720832aa4ec47a8d1dd869c