### PR TITLE
Add soft text glow to title headings

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -8,6 +8,11 @@ body {
   font-family: var(--ff-h);
 }
 
+.title, h1 {
+  color: var(--ink);
+  text-shadow:0 0 8px rgba(255,255,255,.15);
+}
+
 .log, .codey {
   font-family: var(--ff-mono);
 }


### PR DESCRIPTION
## Summary
- Apply `var(--ink)` color and soft white text glow to `.title` and `h1` elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ec2a7b470832a9181554fc4708610