### PR TITLE
feat: add pulsating portal thumb

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,27 @@
   .portal-name{text-align:center; font-weight:600}
   .portal-actions{display:flex; gap:6px}
 
+  .portal-thumb{
+    width:112px;
+    height:112px;
+    border-radius:50%;
+    background-size:cover;
+    position:relative;
+    z-index:0;
+  }
+  .portal-thumb::before{
+    content:"";
+    position:absolute;
+    inset:-4px;
+    border-radius:inherit;
+    background:conic-gradient(from 0deg at 50% 50%, var(--aurora-2), var(--aurora-3), var(--aurora-4), var(--aurora-2));
+    -webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 4px), #000 calc(100% - 4px));
+    mask:radial-gradient(farthest-side,transparent calc(100% - 4px), #000 calc(100% - 4px));
+    filter:blur(2px);
+    animation:pulse 3.6s ease-in-out infinite;
+    pointer-events:none;
+  }
+
   /* Waiting Rooms */
   .wr-grid{display:grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap:20px; margin-top:10px}
   .wr-card{display:grid; gap:8px}
@@ -252,6 +273,11 @@
 #enterApp:active{
   transform:translate(-50%,-50%) scale(.97);
   box-shadow:0 0 10px rgba(30,58,138,.5);
+}
+
+@keyframes pulse{
+  0%,100%{transform:scale(1); opacity:1;}
+  50%{transform:scale(1.05); opacity:.7;}
 }
 
 @keyframes enterPulse{


### PR DESCRIPTION
## Summary
- style `.portal-thumb` as a circular 112px thumbnail
- add conic-gradient ring with pulsing animation
- define `@keyframes pulse` for smooth opacity/scale animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eca2ca8b4832aaac53bbeea0786a7