### PR TITLE
Add focus-visible outline styling

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -17,6 +17,12 @@ body {
   font-family: var(--ff-mono);
 }
 
+:focus-visible {
+  outline:2px solid mix(var(--aurora-3), #fff);
+  outline-offset:3px;
+  border-radius:12px;
+}
+
 /* Aurora theme tokens */
 .theme-aurora {
   --ff-ui: 'Inter', system-ui, sans-serif;


### PR DESCRIPTION
## Summary
- style focus-visible with a custom outline that offsets and rounds the indicator

## Testing
- `npx --yes -p playwright playwright install chromium` *(fails: Error: Download failed: server returned code 403 body 'Domain forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_689ecb873c20832aa377f9f0938b01e9