### PR TITLE
style: add panel header and chip styling

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -83,6 +83,20 @@ body {
   box-shadow:var(--shadow);
 }
 
+.panel .header {
+  font-family: var(--ff-h);
+  font-size: 1.15rem;
+  letter-spacing: .5px;
+}
+
+.chip {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--aurora-1), var(--aurora-3));
+  color: #0f1420;
+}
+
 @keyframes aurora {
   0% {
     transform: translate3d(-10%, -10%, 0) scale(1);


### PR DESCRIPTION
## Summary
- style panel headers with heading font and spacing
- introduce chip component with gradient background and pill shape

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc679310832aa4542c1fe99ed4e8