### PR TITLE
Add transition defaults and reduced motion handling

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -23,6 +23,10 @@ body {
   border-radius:12px;
 }
 
+*, *::before, *::after {
+  transition: color 200ms, background-color 200ms, border-color 200ms;
+}
+
 /* Aurora theme tokens */
 .theme-aurora {
   --ff-ui: 'Inter', system-ui, sans-serif;
@@ -103,5 +107,12 @@ body {
   }
   100% {
     transform: translate3d(10%, 10%, 0) scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- Apply 200ms transitions for color, background-color, and border-color across elements
- Respect user reduced motion preferences by disabling animations and transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ecd68f958832a9f21877314c6237e