### PR TITLE
style: add glass inputs with focus ring

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -125,6 +125,18 @@ body {
   color: #0f1420;
 }
 
+input, textarea, select, .input {
+  background:var(--glass);
+  border:1px solid var(--border);
+  border-radius:12px;
+  backdrop-filter:blur(6px);
+}
+
+input:focus, textarea:focus, select:focus, .input:focus {
+  border-color:var(--aurora-3);
+  box-shadow:0 0 0 4px rgba(69,209,255,.18);
+}
+
 @keyframes aurora {
   0% {
     transform: translateY(calc(var(--parallax) * -1)) translate3d(-10%, -10%, 0) scale(1);


### PR DESCRIPTION
## Summary
- style: give inputs and textareas a glassy background with blur, border, and rounded corners
- style: highlight inputs on focus with aurora-colored border and soft glow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed0b17bfc832aa9fc90c9dabd8082