### PR TITLE
Add base styles for SVG icons

### DIFF
--- a/styles/aurora.css
+++ b/styles/aurora.css
@@ -17,6 +17,16 @@ body {
   font-family: var(--ff-mono);
 }
 
+.icon {
+  width:18px;
+  height:18px;
+  stroke:currentColor;
+  opacity:.9;
+  vertical-align:middle;
+  fill:none;
+  stroke-width:1.5;
+}
+
 :focus-visible {
   outline:2px solid mix(var(--aurora-3), #fff);
   outline-offset:3px;


### PR DESCRIPTION
## Summary
- Add shared `.icon` CSS rule for consistent SVG sizing and appearance
- Enforce `fill:none` and uniform `stroke-width` for icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed143c1f8832aa445dd680db19467