### PR TITLE
Make launch scene background semi-transparent

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@
   .viz-grid{display:grid; grid-template-columns:repeat(auto-fill, minmax(140px,1fr)); gap:12px}
   .viz-thumb{position:relative; width:100%; padding-top:100%; border:1px solid var(--border); border-radius:14px; background:var(--bg-0) center/cover no-repeat; cursor:pointer; overflow:hidden}
   .viz-thumb .cap{position:absolute; inset:auto 0 0 0; padding:6px 8px; background:linear-gradient(180deg, transparent, rgba(0,0,0,.55)); font-size:12px}
-  #launchScene{position:fixed; inset:0; background:var(--bg-0); transition:opacity .5s; z-index:2}
+  #launchScene{position:fixed; inset:0; background:rgba(10,14,22,0.4); transition:opacity .5s; z-index:2}
 /* Launch scene canvas with subtle orb glow */
 #launchScene canvas{
   position:absolute;


### PR DESCRIPTION
## Summary
- allow starfield and aurora to show through launch screen by making `#launchScene` background semi-transparent

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npx playwright install` *(fails: download failure)*

------
https://chatgpt.com/codex/tasks/task_e_689edb699848832a803af158433d6781