### PR TITLE
Remove background from enter button label

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,7 @@
   padding:6px 16px;
   border-radius:6px;
   display:inline-block;
+  background:none;
 }
 
 #enterApp:hover,


### PR DESCRIPTION
## Summary
- Ensure enter button text has no background by explicitly resetting `.enter-label` background

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee036b918832a8a60305517c4e6ca