### PR TITLE
Persist Dropbox metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1294,6 +1294,8 @@ button::-moz-focus-inner{
       appKey:'',
       accessToken:'',
       refreshToken:'',
+      dropboxAccountId:'',
+      dropboxRootPath:'/ShiftingClouds/DRScript',
       path:'/Apps/DR Script Builder/data.json',
       auto:false,
       intervalMins:5,
@@ -1342,7 +1344,10 @@ button::-moz-focus-inner{
   if(!state.projections) state.projections=[];
   if(!state.astralGoals) state.astralGoals=[];
   if(!state.astralTechniques) state.astralTechniques=[];
-  if(!state.sync) state.sync={provider:null, appKey:'', accessToken:'', path:'/Apps/DR Script Builder/data.json', auto:false, intervalMins:5, lastSync:0};
+  if(!state.sync) state.sync={provider:null, appKey:'', accessToken:'', refreshToken:'', dropboxAccountId:'', dropboxRootPath:'/ShiftingClouds/DRScript', path:'/Apps/DR Script Builder/data.json', auto:false, intervalMins:5, lastSync:0};
+  state.sync.dropboxAccountId ||= '';
+  state.sync.dropboxRootPath ||= '/ShiftingClouds/DRScript';
+  state.sync.refreshToken ||= '';
 
   // ===== Utils =====
   const qs = (q)=>document.querySelector(q);
@@ -1367,7 +1372,7 @@ button::-moz-focus-inner{
     }
     if(state.sync){
       try{
-        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider}));
+        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider, dropboxAccountId: state.sync.dropboxAccountId, dropboxRootPath: state.sync.dropboxRootPath}));
       }catch(err){
         if(err?.name==='QuotaExceededError'){
           quota=true;
@@ -4854,9 +4859,11 @@ portalCtx.restore(); // end circular clip
       }
       const data = await res.json();
       state.sync.accessToken = data.access_token;
+      state.sync.dropboxAccountId = data.account_id || state.sync.dropboxAccountId || '';
+      state.sync.dropboxRootPath = state.sync.dropboxRootPath || '/ShiftingClouds/DRScript';
       save();
       try{
-        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider}));
+        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider, dropboxAccountId: state.sync.dropboxAccountId, dropboxRootPath: state.sync.dropboxRootPath}));
       }catch{}
       return true;
     }catch(err){
@@ -5145,7 +5152,7 @@ portalCtx.restore(); // end circular clip
         }
       }
       try{
-        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider}));
+        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider, dropboxAccountId: state.sync.dropboxAccountId, dropboxRootPath: state.sync.dropboxRootPath}));
       }catch(err){
         if(err?.name==='QuotaExceededError'){
           quota=true;
@@ -5196,7 +5203,7 @@ portalCtx.restore(); // end circular clip
         }
       }
       try{
-        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider}));
+        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider, dropboxAccountId: state.sync.dropboxAccountId, dropboxRootPath: state.sync.dropboxRootPath}));
       }catch(err){
         if(err?.name==='QuotaExceededError'){
           quota=true;
@@ -5289,9 +5296,11 @@ portalCtx.restore(); // end circular clip
       state.sync.accessToken = data.access_token;
       state.sync.refreshToken = data.refresh_token;
       state.sync.provider = 'dropbox';
+      state.sync.dropboxAccountId = data.account_id || state.sync.dropboxAccountId || '';
+      state.sync.dropboxRootPath = state.sync.dropboxRootPath || '/ShiftingClouds/DRScript';
       save();
       try{
-        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider}));
+        localStorage.setItem(syncKey, JSON.stringify({accessToken: state.sync.accessToken, refreshToken: state.sync.refreshToken, provider: state.sync.provider, dropboxAccountId: state.sync.dropboxAccountId, dropboxRootPath: state.sync.dropboxRootPath}));
       }catch{}
       params.delete('code');
       params.delete('state');


### PR DESCRIPTION
## Summary
- Save Dropbox account ID and root path alongside access and refresh tokens
- Default root path `/ShiftingClouds/DRScript` and ensure values survive token refresh and OAuth handling

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa5e57c4c832a9faaddb38010a157