### PR TITLE
Add media download planner with IndexedDB caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <link rel="stylesheet" href="styles/aurora.css" />
 <script defer src="scripts/ui-effects.js"></script>
 <script defer src="scripts/perf-metrics.js"></script>
+<script defer src="scripts/media-loader.js"></script>
 <style>
   :root{
     --radius:16px;

--- a/scripts/media-loader.js
+++ b/scripts/media-loader.js
@@ -1,0 +1,108 @@
+(() => {
+  const MEDIA_INDEX_FILE = 'media_index.json';
+  const EAGER_LIMIT = 4 * 1024 * 1024; // 4MB
+
+  function openMediaDB() {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open('media-cache', 1);
+      req.onupgradeneeded = e => {
+        const db = e.target.result;
+        const store = db.createObjectStore('media', { keyPath: 'sha256' });
+        store.createIndex('by-id', 'id', { unique: false });
+      };
+      req.onsuccess = e => resolve(e.target.result);
+      req.onerror = e => reject(e.target.error);
+    });
+  }
+
+  function idbRequest(req) {
+    return new Promise((resolve, reject) => {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function storeBlob(db, item, blob, hash) {
+    const tx = db.transaction('media', 'readwrite');
+    const store = tx.objectStore('media');
+    const existing = await idbRequest(store.get(hash));
+    if (!existing) {
+      await idbRequest(store.put({
+        id: item.id,
+        blob,
+        sha256: hash,
+        mime: item.mime || blob.type || 'application/octet-stream',
+        bytes: item.bytes || blob.size,
+        source: 'dropbox'
+      }));
+    }
+    tx.commit && tx.commit();
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => res();
+      tx.onerror = () => rej(tx.error);
+    });
+  }
+
+  async function sha256(blob) {
+    const buffer = await blob.arrayBuffer();
+    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  async function fetchWithRetry(url, options = {}, retries = 3, delay = 500) {
+    for (let i = 0; i <= retries; i++) {
+      try {
+        const res = await fetch(url, options);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.blob();
+      } catch (err) {
+        if (i === retries) throw err;
+        await new Promise(r => setTimeout(r, delay * Math.pow(2, i)));
+      }
+    }
+  }
+
+  function planDownloads(index) {
+    const eager = [], lazy = [];
+    for (const item of index) {
+      if ((item.bytes || 0) < EAGER_LIMIT) {
+        eager.push(item);
+      } else {
+        lazy.push(item);
+      }
+    }
+    return { eager, lazy };
+  }
+
+  async function loadMedia() {
+    try {
+      const res = await fetch(MEDIA_INDEX_FILE);
+      const index = await res.json();
+      const { eager, lazy } = planDownloads(index);
+      window.lazyMedia = lazy; // placeholders
+
+      const db = await openMediaDB();
+      const missing = [];
+      for (const item of eager) {
+        try {
+          const blob = await fetchWithRetry(item.path, {}, 4);
+          const hash = item.sha256 || await sha256(blob);
+          await storeBlob(db, item, blob, hash);
+        } catch (err) {
+          console.warn('Failed to fetch media', item, err);
+          missing.push(item.id);
+        }
+      }
+      window.missingMediaReport = missing;
+      if (missing.length) {
+        console.table(missing);
+      }
+    } catch (err) {
+      console.error('Failed to load media index', err);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', loadMedia);
+  window.mediaLoader = { openMediaDB, loadMedia, planDownloads };
+})();


### PR DESCRIPTION
## Summary
- load `media_index.json` and plan eager vs lazy downloads
- cache downloaded media blobs in IndexedDB with SHA-256 dedupe
- retry downloads with exponential backoff and log missing media

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/media-loader.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_689fb1424650832aa75366218e4f778f