### PR TITLE
Handle missing Enter App button

### DIFF
--- a/index.html
+++ b/index.html
@@ -6153,25 +6153,30 @@ portalCtx.restore(); // end circular clip
     renderPortalScene();
   });
   // Delay heavy initialization until the user enters the app
-  qs('#enterApp').addEventListener('click', () => {
-    const launch = qs('#launchScene');
-    const app = qs('.app');
-    qs('#portals-view').appendChild(portalCanvas);
-    sizePortalCanvas();
-    renderPortalScene();
-    launch.style.opacity = '0';
-    app.style.display = 'grid';
-    requestAnimationFrame(() => {
-      app.style.opacity = '1';
-      // Use idle callback when available to keep the UI responsive
-      (window.requestIdleCallback || requestAnimationFrame)(() => {
-        renderAll();
-        attachSettingsHandlers();
-        setupAutoSync();
+  const enterBtn = qs('#enterApp');
+  if (!enterBtn) {
+    console.warn('Enter App button not found');
+  } else {
+    enterBtn.addEventListener('click', () => {
+      const launch = qs('#launchScene');
+      const app = qs('.app');
+      qs('#portals-view').appendChild(portalCanvas);
+      sizePortalCanvas();
+      renderPortalScene();
+      launch.style.opacity = '0';
+      app.style.display = 'grid';
+      requestAnimationFrame(() => {
+        app.style.opacity = '1';
+        // Use idle callback when available to keep the UI responsive
+        (window.requestIdleCallback || requestAnimationFrame)(() => {
+          renderAll();
+          attachSettingsHandlers();
+          setupAutoSync();
+        });
       });
+      setTimeout(() => launch.style.display = 'none', 500);
     });
-    setTimeout(() => launch.style.display = 'none', 500);
-  });
+  }
 
   console.log('DR Script Builder loaded successfully');
 </script>


### PR DESCRIPTION
## Summary
- Avoid runtime errors by checking for `#enterApp` before binding click handler
- Warn when the Enter App button is missing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689fb812ded4832ab1abbba641ac4000