### PR TITLE
Fix media index path references

### DIFF
--- a/index.html
+++ b/index.html
@@ -1339,7 +1339,7 @@ button::-moz-focus-inner{
   const SCENARIOS_FILE = 'scenarios.json';
   const CHARACTERS_FILE = 'characters.json';
   const LOCATIONS_FILE = 'locations.json';
-  const MEDIA_INDEX_FILE = 'media_index.json';
+  const MEDIA_INDEX_FILE = 'data/media-index.json';
 
   const DB_NAME = 'drscript';
   const DB_VERSION = 1;
@@ -1428,7 +1428,7 @@ button::-moz-focus-inner{
         scenarios.json
         characters.json
         locations.json
-        media_index.json
+        media-index.json
         media/
           images/
           videos/

--- a/scripts/media-loader.js
+++ b/scripts/media-loader.js
@@ -1,5 +1,5 @@
 (() => {
-  const MEDIA_INDEX_FILE = 'media_index.json';
+  const MEDIA_INDEX_FILE = 'data/media-index.json';
   const EAGER_LIMIT = 4 * 1024 * 1024; // 4MB
 
   function openMediaDB() {


### PR DESCRIPTION
## Summary
- point MEDIA_INDEX_FILE to data/media-index.json
- document media-index.json location in comments

## Testing
- `node -e "const http=require('http');const fs=require('fs');const port=8123;const server=http.createServer((req,res)=>{fs.createReadStream('data/media-index.json').pipe(res);});server.listen(port,async()=>{try{const res=await fetch('http://localhost:'+port+'/');const json=await res.json();console.log('entries',json.length);server.close();}catch(e){console.error('err',e);server.close();}});"`


------
https://chatgpt.com/codex/tasks/task_e_689fbb73fc24832a85fd0761635b76d8