### PR TITLE
feat: improve media index error handling

### DIFF
--- a/scripts/media-loader.js
+++ b/scripts/media-loader.js
@@ -78,7 +78,19 @@
   async function loadMedia() {
     try {
       const res = await fetch(MEDIA_INDEX_FILE);
-      const index = await res.json();
+      if (!res.ok) {
+        throw new Error(`Failed to fetch media index: HTTP ${res.status} ${res.statusText}`);
+      }
+      const contentType = res.headers.get('content-type');
+      if (contentType && !contentType.startsWith('application/json')) {
+        throw new Error(`Unexpected content-type: ${contentType}`);
+      }
+      let index;
+      try {
+        index = await res.json();
+      } catch (err) {
+        throw new Error('Invalid JSON in media index');
+      }
       const { eager, lazy } = planDownloads(index);
       window.lazyMedia = lazy; // placeholders
 

--- a/scripts/media-loader.test.js
+++ b/scripts/media-loader.test.js
@@ -1,0 +1,54 @@
+const fs = require('node:fs');
+const vm = require('node:vm');
+const assert = require('node:assert');
+const { test } = require('node:test');
+const path = require('node:path');
+
+const scriptSrc = fs.readFileSync(path.join(__dirname, 'media-loader.js'), 'utf8');
+
+function setup(fetchImpl) {
+  const errors = [];
+  const sandbox = {
+    console: {
+      error: (...args) => errors.push(args),
+      warn: () => {},
+      log: () => {},
+      table: () => {}
+    },
+    window: {},
+    document: {
+      addEventListener: (evt, handler) => {
+        sandbox._handler = handler;
+      }
+    },
+    fetch: fetchImpl,
+    Response,
+    Headers
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(scriptSrc, sandbox);
+  return { sandbox, errors };
+}
+
+test('loadMedia logs friendly error on missing file', async () => {
+  const fetchImpl = async () => new Response('', { status: 404, statusText: 'Not Found' });
+  const { sandbox, errors } = setup(fetchImpl);
+  await sandbox.window.mediaLoader.loadMedia();
+  assert.strictEqual(errors.length, 1);
+  assert.strictEqual(errors[0][0], 'Failed to load media index');
+  assert.match(errors[0][1].message, /HTTP 404/);
+});
+
+test('loadMedia logs friendly error on invalid JSON', async () => {
+  const fetchImpl = async () =>
+    new Response('not-json', {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+  const { sandbox, errors } = setup(fetchImpl);
+  await sandbox.window.mediaLoader.loadMedia();
+  assert.strictEqual(errors.length, 1);
+  assert.strictEqual(errors[0][0], 'Failed to load media index');
+  assert.match(errors[0][1].message, /Invalid JSON/);
+});
+


### PR DESCRIPTION
## Summary
- validate media index fetch before parsing
- clearly report invalid JSON and non-JSON responses
- add tests for missing index file and malformed JSON

## Testing
- `node --test scripts/media-loader.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fbcf996e4832a9fbadcd603389f5d