### PR TITLE
Standardize hyphen naming for backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-data/local_backups/
+data/local-backups/
 data/merge.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# DR Script Builder
+
+## Naming Convention
+
+File and directory names use hyphen-separated (kebab-case) words. Examples include:
+
+- `scripts/data-sync.js`
+- `data/local-backups/`
+- `collections.json`
+
+This convention keeps paths consistent across tooling and documentation.

--- a/index.html
+++ b/index.html
@@ -5176,7 +5176,7 @@ portalCtx.restore(); // end circular clip
 
   async function listLatestBackup(){
     const root = state.sync?.dropboxRootPath || BACKUP_ROOT_PATH;
-    const path = `${root}/backups`;
+    const path = `${root}/local-backups`;
     let res = await dropboxApiCall('files/list_folder', {body: JSON.stringify({path})});
     let data = await res.json();
     let entries = data.entries || [];
@@ -5197,7 +5197,7 @@ portalCtx.restore(); // end circular clip
 
   async function showBackupPicker(){
     const root = state.sync?.dropboxRootPath || BACKUP_ROOT_PATH;
-    const path = `${root}/backups`;
+    const path = `${root}/local-backups`;
     let res = await dropboxApiCall('files/list_folder', {body: JSON.stringify({path})});
     let data = await res.json();
     let entries = data.entries || [];

--- a/scripts/data-sync.js
+++ b/scripts/data-sync.js
@@ -5,7 +5,7 @@ const path = require('path');
 const DATA_DIR = path.resolve(__dirname, '..', 'data');
 const COLLECTIONS = path.join(DATA_DIR, 'collections.json');
 const MEDIA_INDEX = path.join(DATA_DIR, 'media-index.json');
-const BACKUP_BASE = path.join(DATA_DIR, 'local_backups');
+const BACKUP_BASE = path.join(DATA_DIR, 'local-backups');
 const LOG_FILE = path.join(DATA_DIR, 'merge.log');
 
 function readJson(file) {
@@ -40,7 +40,7 @@ function mergeArrays(existing, incoming, type, conflictDir, conflicts) {
     if (map.has(item.id)) {
       const current = map.get(item.id);
       if (JSON.stringify(current) !== JSON.stringify(item)) {
-        const conflictFile = path.join(conflictDir, `${type}_${item.id}_conflictCopy.json`);
+        const conflictFile = path.join(conflictDir, `${type}-${item.id}-conflict-copy.json`);
         fs.writeFileSync(conflictFile, JSON.stringify(current, null, 2));
         conflicts.push(`${type}:${item.id} -> ${conflictFile}`);
       }


### PR DESCRIPTION
## Summary
- Switch backup directory and conflict filenames to hyphenated format.
- Update Dropbox backup paths accordingly.
- Document hyphen-based file naming in new README.

## Testing
- `node scripts/media-loader.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689fbdd87af8832a9908954f8ff3eb8c