### PR TITLE
Fix invalid assignment in undoRestore handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -5717,7 +5717,10 @@ portalCtx.restore(); // end circular clip
       save();
       renderAll();
       restoreSnapshot = null;
-      qs('#undoRestore')?.style.display='none';
+      const undoBtn = qs('#undoRestore');
+      if(undoBtn){
+        undoBtn.style.display = 'none';
+      }
       setSyncStatus('Restore undone');
     }catch(err){
       console.error('Undo restore failed', err);


### PR DESCRIPTION
## Summary
- prevent SyntaxError from optional chaining assignment when hiding the Undo Restore button

## Testing
- `node --test scripts/media-loader.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fdc4eb3b4832a9a46ebcef535caed