### PR TITLE
Handle missing Dropbox state by restoring latest backup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5232,6 +5232,38 @@ portalCtx.restore(); // end circular clip
     return candidates[idx];
   }
 
+  async function downloadLatestCloudBackup(){
+    const root = state.sync?.dropboxRootPath || BACKUP_ROOT_PATH;
+    let base;
+    try{
+      base = normalizeDropboxPath(`${root}/backups`);
+    }catch(err){
+      alert(err.message + ' Please pick a valid Dropbox file path.');
+      throw err;
+    }
+    let res;
+    try{
+      res = await dropboxApiCall('files/list_folder', {body: JSON.stringify({path: base})});
+    }catch(err){
+      if(err.message?.includes('path/not_found')) return null;
+      throw err;
+    }
+    let data = await res.json();
+    let entries = data.entries || [];
+    while(data.has_more){
+      res = await dropboxApiCall('files/list_folder/continue', {body: JSON.stringify({cursor: data.cursor})});
+      data = await res.json();
+      entries = entries.concat(data.entries || []);
+    }
+    const folders = entries.filter(e=>e['.tag']==='folder');
+    if(folders.length===0) return null;
+    folders.sort((a,b)=>b.name.localeCompare(a.name));
+    const latest = folders[0];
+    const filePath = normalizeDropboxPath(`${base}/${latest.name}/data.json`);
+    const blob = await dbxDownload(filePath);
+    return {blob, path: filePath};
+  }
+
 async function dropboxContentApiCall(endpoint, content, filename, mode = 'overwrite') {
     if(!state.sync?.accessToken) {
       throw new Error('No access token available');
@@ -5844,8 +5876,54 @@ async function dropboxContentApiCall(endpoint, content, filename, mode = 'overwr
         alert(err.message + ' Please pick a valid Dropbox file path.');
         throw err;
       }
-      const file = await dbxDownload(path);
-      const text = await file.text();
+      let blob;
+      {
+        const url = 'https://api.dropboxapi.com/2/files/get_metadata';
+        const headers = {
+          'Authorization': `Bearer ${state.sync.accessToken}`,
+          'Content-Type': 'application/json'
+        };
+        const body = JSON.stringify({path});
+        let res = await fetch(url, {method:'POST', headers, body});
+        if(res.status === 401 && await refreshAccessToken()){
+          headers['Authorization'] = `Bearer ${state.sync.accessToken}`;
+          res = await fetch(url, {method:'POST', headers, body});
+        }
+        if(res.ok){
+          const meta = await res.json();
+          if(meta['.tag'] === 'file'){
+            blob = await dbxDownload(path);
+          }else{
+            throw new Error('Dropbox path must point to a file.');
+          }
+        }else if(res.status === 409){
+          let errData = {};
+          try{ errData = await res.json(); }catch{}
+          if(errData?.error_summary?.includes('not_found')){
+            const backup = await downloadLatestCloudBackup();
+            if(backup){
+              blob = backup.blob;
+              path = backup.path;
+            }else{
+              const msg = 'No cloud state found at /data.json. Save once to create it, or pick a file.';
+              setSyncStatus(msg);
+              alert(msg);
+              throw new Error(msg);
+            }
+          }else{
+            const errText = errData?.error_summary || await res.text();
+            const err = new Error(`Dropbox API error: ${res.status} - ${errText}`);
+            err.status = res.status;
+            throw err;
+          }
+        }else{
+          const errText = await res.text();
+          const err = new Error(`Dropbox API error: ${res.status} - ${errText}`);
+          err.status = res.status;
+          throw err;
+        }
+      }
+      const text = await blob.text();
       const incoming = JSON.parse(text);
       if(incoming?.appVersion && incoming.appVersion > APP_VERSION){
         const err = new Error('Backup version too new');


### PR DESCRIPTION
## Summary
- Validate sync pull target with `files/get_metadata` and fallback to latest `/backups` snapshot when `/data.json` is missing.
- Add `downloadLatestCloudBackup` helper to list `/backups`, select newest timestamped folder, and fetch its `data.json`.

## Testing
- `node scripts/media-loader.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ffeb227bc832ab8649f2643ec81e0