### PR TITLE
Fix portal spawn positions to stay on screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -1977,8 +1977,8 @@ const loadPromises = [];
       p.displayRadius = r;
       const orbitRadius = r * 2;
       const angle = Math.random() * Math.PI * 2;
-      const cx = Math.random() * portalCanvas.width;
-      const cy = Math.random() * portalCanvas.height;
+      const cx = Math.random() * (portalCanvas.width  - 2 * orbitRadius) + orbitRadius;
+      const cy = Math.random() * (portalCanvas.height - 2 * orbitRadius) + orbitRadius;
       const obj = {
         cx,
         cy,


### PR DESCRIPTION
## Summary
- ensure portal orbit centers leave enough room for initial motion so portals start on screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a116693b98832a8bc4fafd9ed6455a